### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/local.settings.json
+++ b/local.settings.json
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AZURE_OPENAI_ENDPOINT": "https://cog-<unique-string>.openai.azure.com/",
+    "AZURE_OPENAI_CHATGPT_DEPLOYMENT": "chat",
+    "OPENAI_API_VERSION": "2023-05-15"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with Azure OpenAI placeholder settings for local development. Requires `azd provision` first to create OpenAI resources, then update the endpoint. Uses Entra identity via DefaultAzureCredential (secretless).

## What's included

`local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: python`
- `AZURE_OPENAI_ENDPOINT: https://cog-<unique-string>.openai.azure.com/`
- `AZURE_OPENAI_CHATGPT_DEPLOYMENT: chat`
- `OPENAI_API_VERSION: 2023-05-15`

## Context

Tracked by Azure/azure-functions-templates#TRACKING_ISSUE — ensuring all manifest templates have `local.settings.json` for local development per review feedback.
